### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 
 after_script:
   - mv tests/_output/coverage.xml clover.xml
-  - ./cc-test-reporter after-build --coverage-input-type clover --id 12345 --exit-code $TRAVIS_TEST_RESULT
+  - ./cc-test-reporter after-build -d --coverage-input-type clover --id 12345 --exit-code $TRAVIS_TEST_RESULT
 
 after_success:
   - codecov


### PR DESCRIPTION
This `-d` flag will allow for debugging information to surface in the CI build, which should help us determine why test reports are not being sent. 