### PR TITLE
#21 User top menu bug

### DIFF
--- a/assets/AdminLteAsset.php
+++ b/assets/AdminLteAsset.php
@@ -10,12 +10,13 @@ class AdminLteAsset extends AssetBundle
 {
     public $sourcePath = '@vendor/almasaeed2010/adminlte';
     public $css = [
-      'dist/css/adminlte.min.css',
+        'dist/css/adminlte.min.css',
     ];
     public $js = [
-    	'dist/js/adminlte.min.js',
+        'dist/js/adminlte.min.js',
     ];
     public $depends = [
         'yii\web\YiiAsset',
+        'yii\bootstrap\BootstrapAsset',
     ];
 }

--- a/assets/AdminLteGuestAsset.php
+++ b/assets/AdminLteGuestAsset.php
@@ -10,12 +10,13 @@ class AdminLteGuestAsset extends AssetBundle
 {
     public $sourcePath = '@vendor/almasaeed2010/adminlte';
     public $css = [
-      'dist/css/adminlte.min.css',
+        'dist/css/adminlte.min.css',
     ];
     public $js = [
         'dist/js/adminlte.min.js',
     ];
     public $depends = [
         'yii\web\YiiAsset',
+        'yii\bootstrap\BootstrapAsset',
     ];
 }

--- a/config/web.php
+++ b/config/web.php
@@ -25,10 +25,15 @@ $config = [
             'appendTimestamp' => true,
             'bundles' => [
                 'yii\bootstrap\BootstrapAsset' => [
-                    'css' => [],
+                    'css' => ['plugins/bootstrap/css/bootstrap.css'],
+                    'sourcePath' => '@vendor/almasaeed2010/adminlte',
                 ],
                 'yii\bootstrap\BootstrapThemeAsset' => [
                     'css' => [],
+                ],
+                'yii\bootstrap\BootstrapPluginAsset' => [
+                    'js' => ['plugins/bootstrap/js/bootstrap.js'],
+                    'sourcePath' => '@vendor/almasaeed2010/adminlte',
                 ],
             ],
         ],

--- a/controllers/MoqupController.php
+++ b/controllers/MoqupController.php
@@ -121,7 +121,7 @@ class MoqupController extends Controller
             $css->updated_at = $now;
             $css->save();
 //            Yii::$app->session->setFlash('success', 'Your new moqup has been saved.');
-            return $this->redirect(['site/design-list']);
+            return $this->redirect(['moqup/design-list']);
         }
         \Yii::$app->getView()->registerJsFile(\Yii::$app->request->BaseUrl . '/js/common.js');
         return $this->render('design-add');
@@ -150,7 +150,7 @@ class MoqupController extends Controller
             $css->updated_at = $now;
             $css->save();
 //            Yii::$app->session->setFlash('success', 'Moqup has been updated.');
-            return $this->redirect(['site/design-list']);
+            return $this->redirect(['moqup/design-list']);
         }
         \Yii::$app->getView()->registerJsFile(\Yii::$app->request->BaseUrl . '/js/common.js');
         return $this->render('design-edit', ['moqup' => $moqup, 'css' => $css]);

--- a/views/layouts/adminlte-main.php
+++ b/views/layouts/adminlte-main.php
@@ -28,7 +28,7 @@ if (!empty($languages)) {
     foreach ($languages as $lang) {
         //Check if the language is the active
         $active = ($lang->code == Yii::$app->language) ? 'active' : '';
-        $langOpt[] = ['label' => Yii::t('language', $lang->name_ascii), 'url' => ['site/change-language', 'lang' => $lang->code], 'options' => ['class' => $active]];
+        $langOpt[] = ['label' => Yii::t('language', $lang->name_ascii), 'url' => ['site/change-language', 'lang' => $lang->code], 'linkOptions' => ['class' => "dropdown-item $active"]];
     }
 }
 
@@ -66,8 +66,23 @@ $currentUrl = Yii::$app->controller->id . '/' . Yii::$app->controller->action->i
                     'size' => 20
                 ]) . ' ' . Yii::$app->user->identity->email,
                 'items' => [
-                    ['label' => Yii::t('app', 'Account'), 'url' => ['site/account'], 'linkOptions' => ['tabindex' => -1]],
-                    ['label' => Yii::t('app', 'Logout'), 'url' => ['site/logout'], 'linkOptions' => ['data-method' => 'post', 'tabindex' => -1]],
+                    [
+                        'label' => Yii::t('app', 'Account'), 
+                        'url' => ['site/account'], 
+                        'linkOptions' => [
+                            'tabindex' => -1, 
+                            'class' => 'dropdown-item ' . ((Yii::$app->controller->id . '/' . Yii::$app->controller->action->id == 'site/account') ? 'active' : ''),
+                        ]
+                    ],
+                    [
+                        'label' => Yii::t('app', 'Logout'), 
+                        'url' => ['site/logout'], 
+                        'linkOptions' => [
+                            'data-method' => 'post', 
+                            'tabindex' => -1, 
+                            'class' => 'dropdown-item'
+                        ]
+                    ],
                 ],
                 'encode' => FALSE,
                 'options' => ['class' => 'nav-item'],
@@ -115,7 +130,7 @@ $currentUrl = Yii::$app->controller->id . '/' . Yii::$app->controller->action->i
                                 <ul class="nav nav-treeview">
                                     <li class="nav-item">
                                         <a href="<?= Yii::$app->urlManager->createUrl(['moqup/design-list']) ?>" class="nav-link <?= in_array($currentUrl, ['moqup/design-list', 'moqup/design-add', 'moqup/design-view', 'moqup/design-edit']) ? 'active' : '' ?>">
-                                            <i class="fa fa-circle-o nav-icon"></i>
+                                            <i class="far fa-circle nav-icon"></i>
                                             <p>Moqups</p>
                                         </a>
                                     </li>


### PR DESCRIPTION
### Description of the Change

In config/web.php
Replaced the yii\bootstrap\BootstrapAsset css file and yii\bootstrap\BootstrapPluginAsset js file for their adminlte bootstrap plugin equivalent

In assets/AdminLteAsset.php, assets/AdminLteGuestAsset.php
Added yii\bootstrap\BootstrapAsset in depends attribute

In views/layouts/adminlte-main.php
Corrected classes for the dropdown items
Corrected icon class in side menu

In controllers/MoqupController.php
The actions designEdit and designAdd were redirecting to site/design-list after save, this was changed for moqup/design-list

### Benefits

The user dropdown menu works again
The tabs in moqup design now works correctly

### Possible Drawbacks

The AdminLTE default styles are not correctly displayed yet


