### PR TITLE
Debuging in production enviroment fixed

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -9,7 +9,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $dotenv = new Dotenv('..');
 $dotenv->load();
 
-defined('YII_DEBUG') or define('YII_DEBUG', getenv('YII_DEBUG'));
+defined('YII_DEBUG') or define('YII_DEBUG', (getenv('YII_DEBUG') == 'true') ? true : false);
 defined('YII_ENV') or define('YII_ENV', getenv('YII_ENV') ?: 'prod');
 
 require __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';


### PR DESCRIPTION
In web/index.php
Created a condition to determine the YII_DEBUG constant value

### Description of the Change
Dotenv deals all the variables as strings, so was added a condition to define the constatnt YII_DEBUG as boolean when env YII_DEBUG variable is 'true'