### PR TITLE
Issue #2 code updated

### DIFF
--- a/controllers/MoqupController.php
+++ b/controllers/MoqupController.php
@@ -24,7 +24,7 @@ class MoqupController extends Controller
         return [
             'access' => [
                 'class' => AccessControl::className(),
-                'only' => ['logout', 'design-list', 'design-view', 'design-edit', 'account'],
+                'only' => ['design-add', 'design-list', 'design-view', 'design-edit', 'design-delete'],
                 'rules' => [
                     [
                         'allow' => true,
@@ -35,7 +35,7 @@ class MoqupController extends Controller
             'verbs' => [
                 'class' => VerbFilter::className(),
                 'actions' => [
-                    'logout' => ['post'],
+                    'design-delete' => ['post'],
                 ],
             ],
         ];
@@ -154,6 +154,29 @@ class MoqupController extends Controller
         }
         \Yii::$app->getView()->registerJsFile(\Yii::$app->request->BaseUrl . '/js/common.js');
         return $this->render('design-edit', ['moqup' => $moqup, 'css' => $css]);
+    }
+
+    public function actionDesignDelete($id)
+    {
+        $moqup = Moqup::findOne($id);
+
+        $css = Css::find()
+            ->where(['moqup_id' => $id])
+            ->one();
+
+        if ($moqup != null) {
+            if ($css != null) {
+                if (!$css->delete()) {
+                    return false;
+                }
+            }
+
+            if ($moqup->delete()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/migrations/m180822_083413_create_moqup_table.php
+++ b/migrations/m180822_083413_create_moqup_table.php
@@ -13,18 +13,27 @@ class m180822_083413_create_moqup_table extends Migration {
     public function safeUp() {
         $this->createTable('moqup', [
             'id' => $this->primaryKey()->unsigned(),
-            'user_id' => $this->integer()->notNull()->unsigned(),
+            'user_id' => $this->integer()->notNull(),
             'title' => $this->string()->notNull(),
             'html' => $this->text()->notNull(),
             'created_at' => $this->integer()->unsigned(),
             'updated_at' => $this->integer()->unsigned()
         ]);
+
+        $this->addForeignKey(
+            'moqup_user_id_fk',
+            'moqup', 
+            'user_id', 
+            'user',
+            'id'
+        );
     }
 
     /**
      * {@inheritdoc}
      */
     public function safeDown() {
+        $this->dropForeignKey('moqup_user_id_fk', 'moqup');
         $this->dropTable('moqup');
     }
 

--- a/migrations/m180822_083418_create_css_table.php
+++ b/migrations/m180822_083418_create_css_table.php
@@ -18,12 +18,21 @@ class m180822_083418_create_css_table extends Migration {
             'created_at' => $this->integer()->unsigned(),
             'updated_at' => $this->integer()->unsigned()
         ]);
+
+        $this->addForeignKey(
+            'css_moqup_id_fk',
+            'css', 
+            'moqup_id', 
+            'moqup',
+            'id'
+        );
     }
 
     /**
      * {@inheritdoc}
      */
     public function safeDown() {
+        $this->dropForeignKey('css_moqup_id_fk', 'css');
         $this->dropTable('css');
     }
 

--- a/models/Css.php
+++ b/models/Css.php
@@ -3,20 +3,75 @@
 namespace app\models;
 
 use Yii;
-use yii\db\ActiveRecord;
 
 /**
- * Moqup model
+ * This is the model class for table "css".
  *
+ * @property int $id
+ * @property int $moqup_id
+ * @property string $css
+ * @property int $created_at
+ * @property int $updated_at
  *
+ * @property Moqup $moqup
  */
-class Css extends \yii\db\ActiveRecord {
+class Css extends \yii\db\ActiveRecord
+{
+    /**
+     * {@inheritdoc}
+     */
+    public static function tableName()
+    {
+        return 'css';
+    }
 
     /**
      * {@inheritdoc}
      */
-    public static function tableName() {
-        return 'css';
+    public function rules()
+    {
+        return [
+            [['moqup_id'], 'required'],
+            [['moqup_id', 'created_at', 'updated_at'], 'integer'],
+            [['created_at'], 'default', 'value' => time()],
+            [['css'], 'string'],
+            [['moqup_id'], 'exist', 'skipOnError' => true, 'targetClass' => Moqup::className(), 'targetAttribute' => ['moqup_id' => 'id']],
+        ];
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function attributeLabels()
+    {
+        return [
+            'id' => Yii::t('moqup', 'ID'),
+            'moqup_id' => Yii::t('moqup', 'Moqup ID'),
+            'css' => Yii::t('moqup', 'Css'),
+            'created_at' => Yii::t('moqup', 'Created At'),
+            'updated_at' => Yii::t('moqup', 'Updated At'),
+        ];
+    }
+
+    /**
+     * @return \yii\db\ActiveQuery
+     */
+    public function getMoqup()
+    {
+        return $this->hasOne(Moqup::className(), ['id' => 'moqup_id']);
+    }
+
+    /**
+     * Make some changes before the record is saved
+     */
+    public function beforeSave($insert)
+    {
+        if (!parent::beforeSave($insert)) {
+            return false;
+        }
+
+        $this->updated_at = time();
+
+        return true;
+    }
 }

--- a/models/Moqup.php
+++ b/models/Moqup.php
@@ -21,12 +21,62 @@ class Moqup extends \yii\db\ActiveRecord
         return 'moqup';
     }
 
+    /** 
+     * {@inheritdoc} 
+     */ 
     public function rules()
     {
         return [
-            // email and password are both required
-            [['title', 'html'], 'required']
+            [['user_id', 'title', 'html'], 'required'],
+            [['user_id', 'created_at', 'updated_at'], 'integer'],
+            [['created_at'], 'default', 'value' => time()],
+            [['html'], 'string'],
+            [['title'], 'string', 'max' => 255],
         ];
     }
 
+    /** 
+     * {@inheritdoc} 
+     */ 
+    public function attributeLabels() 
+    { 
+        return [ 
+            'id' => Yii::t('moqup', 'ID'), 
+            'user_id' => Yii::t('moqup', 'User'), 
+            'title' => Yii::t('moqup', 'Title'), 
+            'html' => Yii::t('moqup', 'Html'), 
+            'created_at' => Yii::t('moqup', 'Created At'), 
+            'updated_at' => Yii::t('moqup', 'Updated At'), 
+        ]; 
+    } 
+
+    /** 
+     * @return \yii\db\ActiveQuery 
+     */ 
+    public function getCss() 
+    { 
+        return $this->hasOne(Css::className(), ['moqup_id' => 'id']); 
+    }
+
+    /** 
+     * @return \yii\db\ActiveQuery 
+     */ 
+    public function getUser() 
+    { 
+        return $this->hasOne(User::className(), ['id' => 'user_id']); 
+    }
+
+    /**
+     * Make some changes before the record is saved
+     */
+    public function beforeSave($insert)
+    {
+        if (!parent::beforeSave($insert)) {
+            return false;
+        }
+
+        $this->updated_at = time();
+
+        return true;
+    }
 }

--- a/models/MoqupSearch.php
+++ b/models/MoqupSearch.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace app\models;
+
+use Yii;
+use yii\base\Model;
+use yii\data\ActiveDataProvider;
+use app\models\Moqup;
+
+/**
+ * MoqupSearch represents the model behind the search form of `app\models\Moqup`.
+ */
+class MoqupSearch extends Moqup
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function rules()
+    {
+        return [
+            [['id', 'user_id', 'created_at', 'updated_at'], 'integer'],
+            [['title', 'html'], 'safe'],
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function scenarios()
+    {
+        // bypass scenarios() implementation in the parent class
+        return Model::scenarios();
+    }
+
+    /**
+     * Creates data provider instance with search query applied
+     *
+     * @param array $params
+     *
+     * @return ActiveDataProvider
+     */
+    public function search($params)
+    {
+        $query = Moqup::find();
+
+        // add conditions that should always apply here
+
+        $dataProvider = new ActiveDataProvider([
+            'query' => $query,
+        ]);
+
+        $this->load($params);
+
+        if (isset($params['viewYours']) && $params['viewYours']) {
+            $query->andFilterWhere(['user_id' => Yii::$app->user->identity->id]);
+        } else {
+            $query->andFilterWhere(['!=', 'user_id', Yii::$app->user->identity->id]);
+        }
+
+        if (!$this->validate()) {
+            return $dataProvider;
+        }
+
+        return $dataProvider;
+    }
+}

--- a/views/moqup/design-edit.php
+++ b/views/moqup/design-edit.php
@@ -2,73 +2,84 @@
 /* @var $this \yii\web\View */
 
 use yii\helpers\Html;
+use yii\widgets\ActiveForm;
 
-$this->title = Yii::t('menu', 'Edit design');
+$this->title = Yii::t('menu', ($moqup->isNewRecord) ? 'Add design' : 'Edit design');
+$this->beginBlock('content-header-data');
+$this->endBlock();
 ?>
+<?php $form = ActiveForm::begin(); ?>
 <div class="card">
     <div class="card-header d-flex p-0">
         <h3 class="card-title p-3">
-            Edit Moqup
+            <?= ($moqup->isNewRecord) ? Yii::t('moqup', 'Add Moqup') : Yii::t('moqup', 'Edit Moqup') ?>
         </h3>
     </div>
-    <?php
-    if (!empty($moqup)) {
-        ?>
-        <form method="post">
-            <input id="form-token" type="hidden" name="<?= Yii::$app->request->csrfParam ?>" value="<?= Yii::$app->request->csrfToken ?>"/>
-            <div class="card-body">
-                <div class="alert alert-info">
-                    <h5><i class="icon fa fa-info"></i> Important!</h5>
-                    Use UI elements from <?= Html::a('AdminLTE 3', 'https://adminlte.io/themes/dev/AdminLTE/index3.html') ?> and <?= Html::a('Bootstrap 4', 'https://getbootstrap.com/docs/4.1/getting-started/introduction/') ?> examples.
-                </div>
-                <div class="row">
-                    <div class="col-md-12">
-                        <div class="form-group">
-                            <label for="pageTitle">Title</label>
-                            <input type="text" class="form-control" id="title" name="title" required="required" value="<?= $moqup->title; ?>">
-                        </div>
+    <div class="card-body">
+        
+        <div class="alert alert-info">
+            <h5><i class="icon fa fa-info"></i> Important!</h5>
+            Use UI elements from <?= Html::a('AdminLTE 3', 'https://adminlte.io/themes/dev/AdminLTE/index3.html') ?> and <?= Html::a('Bootstrap 4', 'https://getbootstrap.com/docs/4.1/getting-started/introduction/') ?> examples.
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <?= $form->field($moqup, 'title')->textInput() ?>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <?= Html::ul([
+                    Html::a('HTML', '#html', ['class' => 'nav-link active', 'data-toggle' => 'tab']),
+                    Html::a('CSS (optional)', '#css', ['class' => 'nav-link', 'data-toggle' => 'tab']),
+                    Html::a('Preview', '#preview', ['class' => 'nav-link', 'data-toggle' => 'tab']),
+                ], [
+                    'class' => 'nav nav-pills ml-auto p-2',
+                    'encode' => false,
+                    'itemOptions' => ['class' => 'nav-item']
+                ]) ?>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="tab-content p-0">
+                    <div class="tab-pane active" id="html">
+                        <?= $form->field($moqup, 'html')->textArea([
+                            'rows' => 10,
+                            'max-length' => 100000,
+                        ])->label(false) ?>
                     </div>
-                    <div class="col-md-12">
-                        <ul class="nav nav-pills ml-auto p-2">
-                            <li class="nav-item">
-                                <a class="nav-link active" href="#html" data-toggle="tab">HTML</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="#css" data-toggle="tab">CSS (optional)</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link" href="#preview" data-toggle="tab">Preview</a>
-                            </li>
-                        </ul>
+                    <div class="tab-pane" id="css">
+                        <?= $form->field($css, 'css')->textArea([
+                            'rows' => 10,
+                            'max-length' => 100000,
+                        ])->label(false) ?>
                     </div>
-                    <div class="col-md-12">
-                        <div class="tab-content p-0">
-                            <div class="tab-pane active" id="html">
-                                <textarea class="form-control" name="html" rows="10" required="required" maxlength="100000"><?= $moqup->html; ?></textarea>
-                            </div>
-                            <div class="tab-pane" id="css">
-                                <textarea name="css" class="form-control" rows="10" maxlength="100000">
-                                    <?php
-                                    if (!empty($css)) {
-                                        echo $css->css;
-                                    }
-                                    ?>
-                                </textarea>
-                            </div>
-                            <div class="tab-pane" id="preview">
-                                <p>Coming soon</p>
-                            </div>
-                        </div>
+                    <div class="tab-pane" id="preview">
+                        <p>Coming soon</p>
                     </div>
                 </div>
             </div>
-            <div class="card-footer">
-                <button type="submit" class="btn btn-success">Save</button>
-                <a type="button" href="<?= Yii::$app->urlManager->createUrl(['moqup/design-list']) ?>" class="btn btn-secondary"> Cancel</a>
-                <button type="button" class="btn btn-outline-danger float-right"> Delete</button>
-            </div>
-        </form>
-        <?php
-    }
-    ?>   
+        </div>
+    </div>
+    <div class="card-footer">
+        <?= Html::submitButton(Yii::t('app', 'Save'), ['class' => 'btn btn-success']) ?>
+        <?= Html::a(Yii::t('app', 'Cancel'), ['moqup/design-list'], ['class' => 'btn btn-secondary']) ?>
+        
+        <?php if (!$moqup->isNewRecord): ?>
+            <?= Html::a(Yii::t('app', 'Delete'), '#', [
+                'class' => 'btn btn-danger float-right',
+                'onclick' => 'if (confirm("' . Yii::t('moqup', 'Are you sure you want to delete this moqup?') . '")) {
+                    $.post("' . (Yii::$app->urlManager->createUrl(['moqup/design-delete/', 'id' => $moqup->id])) . '", {}, function(result) {
+                        if (result == "1") {
+                            location.href="' . (Yii::$app->urlManager->createUrl(['moqup/design-list', 'viewYours' => true])) . '";
+                        }
+                        else {
+                            alert("' . Yii::t('moqup', 'Sorry, there was an error while trying to delete the moqup') . '");
+                        }
+                    });
+                }',
+            ]) ?>
+        <?php endif; ?>
+    </div>
 </div>
+<?php ActiveForm::end(); ?>

--- a/views/moqup/design-list.php
+++ b/views/moqup/design-list.php
@@ -59,7 +59,24 @@ $this->title = Yii::t('menu', 'Moqups');
                                         echo $moqup_date;
                                         ?>
                                     </td>
-                                    <td class="text-right"><a href="<?= Url::to(['moqup/design-view/', 'id' => $moqup['id']]); ?>" target="_blank"><button type="button" class="btn btn-sm btn-outline-primary"  data-toggle="tooltip" data-placement="top" title="Preview"><i class="fas fa-external-link-alt"></i></button></a><a href="<?= Url::to(['moqup/design-edit/', 'id' => $moqup['id']]); ?>"> <button type="button" class="btn btn-sm btn-outline-secondary"  data-toggle="tooltip" data-placement="top" title="Edit"><i class="fas fa-edit"></i></button></a> <button type="button" class="btn btn-sm btn-outline-danger"  data-toggle="tooltip" data-placement="top" title="Delete"><i class="fas fa-trash-alt"></i></button></td>
+                                    <td class="text-right">
+                                        <a href="<?= Url::to(['moqup/design-view/', 'id' => $moqup['id']]); ?>" target="_blank">
+                                            <button type="button" class="btn btn-sm btn-outline-primary"  data-toggle="tooltip" data-placement="top" title="Preview">
+                                                <i class="fas fa-external-link-alt"></i>
+                                            </button>
+                                        </a>
+                                        <a href="<?= Url::to(['moqup/design-edit/', 'id' => $moqup['id']]); ?>">
+                                            <button type="button" class="btn btn-sm btn-outline-secondary"  data-toggle="tooltip" data-placement="top" title="Edit">
+                                                <i class="fas fa-edit"></i>
+                                            </button>
+                                        </a>
+                                        <?= Html::a('<button type="button" class="btn btn-sm btn-outline-danger"  data-toggle="tooltip" data-placement="top" title="Delete"> '
+                                                . '<i class="fas fa-trash-alt"></i> '
+                                            . '</button>', ['moqup/design-delete/', 'id' => $moqup['id']], [
+                                                'data-method' => 'post',
+                                                'class' => 'delete-moqup-anchor',
+                                            ]) ?>
+                                    </td>
                                 </tr>
                                 <?php
                             }
@@ -90,3 +107,22 @@ $this->title = Yii::t('menu', 'Moqups');
         </div>
     </div>
 </div>
+
+<?php
+$this->registerJs('$(".delete-moqup-anchor").click(function(event) {
+    event.preventDefault();
+    var url = $(this).attr("href");
+
+    if (confirm("' . Yii::t('moqup', 'Are you sure you want to delete this moqup?') . '")) {
+        $.post(url, {}, function(result) {
+            if (result == "1") {
+                location.reload();
+            }
+            else {
+                alert("' . Yii::t('moqup', 'Sorry, there was an error while trying to delete the moqup') . '");
+            }
+        });
+    } 
+
+    return false;
+});');

--- a/views/moqup/design-list.php
+++ b/views/moqup/design-list.php
@@ -3,9 +3,12 @@
 
 use yii\helpers\Url;
 use yii\helpers\Html;
+use yii\grid\GridView;
+use yii\widgets\Pjax;
 
 $this->title = Yii::t('menu', 'Moqups');
 ?>
+<?php Pjax::begin(); ?>
 <div class="card">
     <div class="card-header d-flex p-0">
         <h3 class="card-title p-3">
@@ -13,103 +16,100 @@ $this->title = Yii::t('menu', 'Moqups');
         </h3>
         <ul class="nav nav-pills ml-auto p-2">
             <li class="nav-item align-self-center mr-4">
-                <a href="<?= Yii::$app->urlManager->createUrl(['moqup/design-add']) ?>"><button type="button" class="btn btn-outline-success" data-toggle="tooltip" data-placement="top" title="Create New"><i class="fa fa-plus"></i></button></a>
-            </li>
-            <?php
-            $all_active = '';
-            $your_active = '';
-            if ($viewMode) {
-                $your_active = ' active';
-            } else {
-                $all_active = ' active';
-            }
-            ?>
-            <li class="nav-item">
-                <a class="nav-link show<?= $all_active; ?>" href="<?= Yii::$app->urlManager->createUrl(['moqup/design-list']) ?>">All <span class="badge badge-light ml-1"><?= count($moqups); ?></span></a>
+                <a href="<?= Yii::$app->urlManager->createUrl(['moqup/design-edit']) ?>">
+                    <button type="button" class="btn btn-outline-success" data-toggle="tooltip" data-placement="top" title="Create New">
+                        <i class="fa fa-plus"></i>
+                    </button>
+                </a>
             </li>
             <li class="nav-item">
-                <a class="nav-link<?= $your_active; ?>" href="<?= Url::to(['moqup/design-list/', 'viewMode' => '1']); ?>">Your <span class="badge badge-light ml-1"><?= count($your_moqups); ?></span></a>
+                <?= Html::a(Yii::t('moqup', 'All') . ' <span class="badge badge-light ml-1">' . $countAll . '</span>', 
+                    ['moqup/design-list'], [
+                        'class' => 'nav-link show ' . ($viewYours != 1 ? 'active' : ''),
+                    ]); ?>
+            </li>
+            <li class="nav-item">
+                <?= Html::a(Yii::t('moqup', 'Yours') . ' <span class="badge badge-light ml-1">' . $countYours . '</span>', 
+                    ['moqup/design-list', 'viewYours' => 1], [
+                        'class' => 'nav-link ' . ($viewYours == 1 ? ' active' : ''),
+                    ]); ?>
             </li>
         </ul>
     </div>
     <div class="card-body p-0">
-        <div class="card-body table-responsive p-0">
-            <table class="table table-hover" id="list_table">
-                <thead>
-                    <tr>
-                        <th>Title</th>
-                        <th>User</th>
-                        <th>Date</th>
-                        <th data-orderable="false"></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <?php
-                    if ($viewMode) {
-                        if (count($your_moqups) > 0) {
-                            foreach ($your_moqups as $moqup) {
-                                ?>
-                                <tr>
-                                    <td><?= $moqup['title']; ?></td>
-                                    <td><?= $moqup['username']; ?></td>
-                                    <td>
-                                        <?php
-                                        $formatter = \Yii::$app->formatter;
-                                        $moqup_date = $formatter->asDate($moqup['created_at']);
-                                        echo $moqup_date;
-                                        ?>
-                                    </td>
-                                    <td class="text-right">
-                                        <a href="<?= Url::to(['moqup/design-view/', 'id' => $moqup['id']]); ?>" target="_blank">
-                                            <button type="button" class="btn btn-sm btn-outline-primary"  data-toggle="tooltip" data-placement="top" title="Preview">
-                                                <i class="fas fa-external-link-alt"></i>
-                                            </button>
-                                        </a>
-                                        <a href="<?= Url::to(['moqup/design-edit/', 'id' => $moqup['id']]); ?>">
-                                            <button type="button" class="btn btn-sm btn-outline-secondary"  data-toggle="tooltip" data-placement="top" title="Edit">
-                                                <i class="fas fa-edit"></i>
-                                            </button>
-                                        </a>
-                                        <?= Html::a('<button type="button" class="btn btn-sm btn-outline-danger"  data-toggle="tooltip" data-placement="top" title="Delete"> '
-                                                . '<i class="fas fa-trash-alt"></i> '
-                                            . '</button>', ['moqup/design-delete/', 'id' => $moqup['id']], [
-                                                'data-method' => 'post',
-                                                'class' => 'delete-moqup-anchor',
-                                            ]) ?>
-                                    </td>
-                                </tr>
-                                <?php
-                            }
+        <?= GridView::widget([
+            'dataProvider' => $dataProvider,
+            'filterModel' => $searchModel,
+            'filterPosition' => false,
+            'summary' => false,
+            'tableOptions' => ['class' => 'table table-hover'],
+            'columns' => [
+                [
+                    'attribute' => 'title',
+                    'contentOptions' => ['style' => 'width: ' . (($viewYours) ? '45%' : '25%') . '; white-space: normal']
+                ],
+                [
+                    'attribute' => 'user_id',
+                    'contentOptions' => ['style' => 'width: 20%; white-space: normal'],
+                    'value' => function($model){
+                        return $model->user->username;
+                    },
+                    'visible' => $viewYours == false,
+                ],
+                [
+                    'attribute' => 'created_at',
+                    'contentOptions' => ['style' => 'width: 20%; white-space: normal'],
+                    'format' => ['date', 'php:Y-m-d h:i a']
+                ],
+                [
+                    'attribute' => 'updated_at',
+                    'contentOptions' => ['style' => 'width: 20%; white-space: normal'],
+                    'format' => ['date', 'php:Y-m-d h:i a']
+                ],
+                
+                [
+                    'class' => 'yii\grid\ActionColumn',
+                    'buttons' => [
+                        'view' => function ($url, $model, $key) {
+                            $content = '<i class="fas fa-external-link-alt"></i>';
+                            return Html::a($content, ['moqup/design-view/', 'id' => $model->id], [
+                                'data-pjax' => 0,
+                                'target' => '_blank',
+                                'class' => 'btn btn-sm btn-outline-primary',
+                                'title' => 'View',
+                            ]);
+                        },
+                        'update' => function ($url, $model, $key) {
+                            $content = '<i class="fas fa-edit"></i>';
+                            return Html::a($content, ['moqup/design-edit/', 'id' => $model->id], [
+                                'data-pjax' => 0,
+                                'class' => 'btn btn-sm btn-outline-secondary',
+                                'title' => 'Edit',
+                            ]);
+                        },
+                        'delete' => function ($url, $model, $key) {
+                            $content = '<i class="fas fa-trash-alt"></i>';
+                            return Html::a($content, ['moqup/design-delete/', 'id' => $model->id], [
+                                'data-pjax' => 0,
+                                'data-method' => 'post',
+                                'class' => 'delete-moqup-anchor btn btn-sm btn-outline-danger',
+                                'title' => 'Delete',
+                            ]);
                         }
-                    } else {
-                        if (count($moqups) > 0) {
-                            foreach ($moqups as $moqup) {
-                                ?>
-                                <tr>
-                                    <td><?= $moqup['title']; ?></td>
-                                    <td><?= $moqup['username']; ?></td>
-                                    <td>
-                                        <?php
-                                        $moqup_date_time = strtotime($moqup['created_at']);
-                                        $moqup_date = date('d-m-Y', $moqup_date_time);
-                                        echo $moqup_date;
-                                        ?>
-                                    </td>
-                                    <td class="text-right"><a href="<?= Url::to(['moqup/design-view/', 'id' => $moqup['id']]); ?>" target="_blank"><button type="button" class="btn btn-sm btn-outline-primary"  data-toggle="tooltip" data-placement="top" title="Preview"><i class="fas fa-external-link-alt"></i></button></a></td>
-                                </tr>
-                                <?php
-                            }
-                        }
-                    }
-                    ?>
-                </tbody>
-            </table>
-        </div>
+                    ],
+                    'visibleButtons' => [
+                        'update' => $viewYours,
+                        'delete' => $viewYours,
+                    ],
+                ],
+            ],
+        ]); ?>
     </div>
 </div>
 
+
 <?php
-$this->registerJs('$(".delete-moqup-anchor").click(function(event) {
+$this->registerJs('$(".delete-moqup-anchor").on("click", function(event) {
     event.preventDefault();
     var url = $(this).attr("href");
 
@@ -126,3 +126,5 @@ $this->registerJs('$(".delete-moqup-anchor").click(function(event) {
 
     return false;
 });');
+
+Pjax::end();


### PR DESCRIPTION
### Requirements

To run the new migrations:
Revert the m180822_083413_create_moqup_table and m180822_083418_create_css_table migrations **before merge**, otherwise will get an error, because the revert will try to delete the new foreign keys and actually they don't exists

### Description of the Change
In m180822_083413_create_moqup_table, m180822_083418_create_css_table
Added foreign keys

In models/Moqup, models/Css 
Added functionality and validations

Created MoqupSearch

In MoqupController
Removed captcha action
Updated designList, designView actions
Merged designEdit, designAdd actions
Added designDelete action

In views/moqup/design-list
Added yii Gridview
Added pjax
Changed some code to yii style

In views/moqup/design-edit
Adapted to work registering and updating records

### Aditional note
views/moqup/design-add is not used anymore
