### PR TITLE
disable undeclared property class phan checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -19,6 +19,11 @@ plugins:
     enabled: true
     config:
       file_extensions: "php"
+    checks:
+      PhanUndeclaredClassMethod:
+        enabled: false
+      PhanUndeclaredProperty:
+        enabled: false
   phpcodesniffer:
     enabled: true
     config:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

@pro2847 requested that these 2 Code Climate checks be disabled.

