### PR TITLE
Fix bug for a command /lang

### DIFF
--- a/models/BotHandler.php
+++ b/models/BotHandler.php
@@ -117,7 +117,7 @@ class BotHandler extends BotApi
         ]);
 
         # case: when group has only 1 language
-        $all_languages = SupportGroupLanguage::findAll(['support_group_id' => $this->support_group_id]);
+        $all_languages = $this->allLanguages();
         if (count($all_languages) == 1) {
             $this->_language_code = $all_languages[0]->language_code;
         }
@@ -248,7 +248,19 @@ class BotHandler extends BotApi
             $supportGroup->save();
 
             return $default_response ? $this->generateDefaultResponse() : true;
-        } elseif (trim($this->getMessage()->getText()) == '/lang' || $this->_language_code == null) {
+        } elseif (trim($this->getMessage()->getText()) == '/lang' || $this->_language_code == null) {               
+            # when group has only 1 language
+            $all_languages = $this->allLanguages();
+            if (count($all_languages) == 1)  {
+                #if command /land setting  send our response  
+                $commands = $this->executeCommand();  
+                if($commands->command == '/lang'){
+                   return $this->generateResponse($commands->supportGroupCommandTexts);                    
+                }
+                #if command /land not setting  send defult response
+                return $this->generateDefaultResponse();
+            }
+            
             $output = '';
 
             $availableLanguagesName = SupportGroupLanguage::find()
@@ -289,15 +301,19 @@ class BotHandler extends BotApi
                 'supportGroupBot',
                 'supportGroupCommandTexts',
             ])
-            ->one();
-
+            ->one(); 
+         
         if (!$commands) {
             return $this->generateDefaultResponse();
-        }
+        }  
+        
+        if ($commands->command === '/lang') {
+            return $commands; 
+        } 
 
         return $this->generateResponse($commands->supportGroupCommandTexts);
     }
-
+    
     /**
      * @return bool|int
      * @throws \yii\db\Exception
@@ -423,6 +439,14 @@ class BotHandler extends BotApi
         ]);
 
         return $model->save();
+    }
+    
+     /**
+     * @return array
+     */
+    public function allLanguages()
+    {
+        return SupportGroupLanguage::findAll(['support_group_id' => $this->support_group_id]);
     }
 
     /**

--- a/models/BotHandler.php
+++ b/models/BotHandler.php
@@ -117,9 +117,9 @@ class BotHandler extends BotApi
         ]);
 
         # case: when group has only 1 language
-        $all_languages = $this->allLanguages();
-        if (count($all_languages) == 1) {
-            $this->_language_code = $all_languages[0]->language_code;
+        $languages = $this->getLanguages();
+        if (count($languages) == 1) {
+            $this->_language_code = $languages[0]->language_code;
         }
 
         #default language
@@ -250,11 +250,11 @@ class BotHandler extends BotApi
             return $default_response ? $this->generateDefaultResponse() : true;
         } elseif (trim($this->getMessage()->getText()) == '/lang' || $this->_language_code == null) {               
             # when group has only 1 language
-            $all_languages = $this->allLanguages();
-            if (count($all_languages) == 1)  {
+            $languages = $this->getLanguages();
+            if (count($languages) == 1) {
                 #if command /land setting  send our response  
                 $commands = $this->executeCommand();  
-                if($commands->command == '/lang'){
+                if ($commands->command == '/lang') {
                    return $this->generateResponse($commands->supportGroupCommandTexts);                    
                 }
                 #if command /land not setting  send defult response
@@ -444,7 +444,7 @@ class BotHandler extends BotApi
      /**
      * @return array
      */
-    public function allLanguages()
+    public function getLanguages()
     {
         return SupportGroupLanguage::findAll(['support_group_id' => $this->support_group_id]);
     }

--- a/models/BotHandler.php
+++ b/models/BotHandler.php
@@ -117,7 +117,7 @@ class BotHandler extends BotApi
         ]);
 
         # case: when group has only 1 language
-        $languages = $this->getLanguages();
+        $languages = $this->getLanguagesByGroup();
         if (count($languages) == 1) {
             $this->_language_code = $languages[0]->language_code;
         }
@@ -250,7 +250,7 @@ class BotHandler extends BotApi
             return $default_response ? $this->generateDefaultResponse() : true;
         } elseif (trim($this->getMessage()->getText()) == '/lang' || $this->_language_code == null) {               
             # when group has only 1 language
-            $languages = $this->getLanguages();
+            $languages = $this->getLanguagesByGroup();
             if (count($languages) == 1) {
                 #if command /land setting  send our response  
                 $commands = $this->executeCommand();  
@@ -444,7 +444,7 @@ class BotHandler extends BotApi
      /**
      * @return array
      */
-    public function getLanguages()
+    public function getLanguagesByGroup()
     {
         return SupportGroupLanguage::findAll(['support_group_id' => $this->support_group_id]);
     }


### PR DESCRIPTION
If there is one language in the group,  command /lang will return the default response. If there is one language in the group and the /lang command is setting, then when it is called, it will return the setting response
