### PR TITLE
Fix bug for a command /lang.

### DIFF
--- a/models/BotHandler.php
+++ b/models/BotHandler.php
@@ -74,6 +74,8 @@ class BotHandler extends BotApi
     protected $_location_at = null;
 
 
+    const LANG = '/lang';
+
     /**
      * Constructor
      *
@@ -117,9 +119,9 @@ class BotHandler extends BotApi
         ]);
 
         # case: when group has only 1 language
-        $all_languages = SupportGroupLanguage::findAll(['support_group_id' => $this->support_group_id]);
-        if (count($all_languages) == 1) {
-            $this->_language_code = $all_languages[0]->language_code;
+        $languages = $this->getLanguagesByGroup();
+        if (count($languages) == 1) {
+            $this->_language_code = $languages[0]->language_code;
         }
 
         #default language
@@ -248,7 +250,19 @@ class BotHandler extends BotApi
             $supportGroup->save();
 
             return $default_response ? $this->generateDefaultResponse() : true;
-        } elseif (trim($this->getMessage()->getText()) == '/lang' || $this->_language_code == null) {
+        } elseif (trim($this->getMessage()->getText()) == self::LANG || $this->_language_code == null) {
+            # when group has only 1 language
+            $languages = $this->getLanguagesByGroup();
+            if (count($languages) == 1) {
+                #if command /land setting  send our response
+                $commands = $this->executeCommand();
+                if ($commands->command === self::LANG) {
+                   return $this->generateResponse($commands->supportGroupCommandTexts);
+                }
+                #if command /land not setting  send defult response
+                return $this->generateDefaultResponse();
+            }
+
             $output = '';
 
             $availableLanguagesName = SupportGroupLanguage::find()
@@ -293,6 +307,10 @@ class BotHandler extends BotApi
 
         if (!$commands) {
             return $this->generateDefaultResponse();
+        }
+
+        if ($commands->command === self::LANG) {
+            return $commands;
         }
 
         return $this->generateResponse($commands->supportGroupCommandTexts);
@@ -423,6 +441,14 @@ class BotHandler extends BotApi
         ]);
 
         return $model->save();
+    }
+
+     /**
+     * @return array
+     */
+    public static function getLanguagesByGroup()
+    {
+        return SupportGroupLanguage::findAll(['support_group_id' => self::support_group_id]);
     }
 
     /**


### PR DESCRIPTION
If there is one language in the group, command /lang will return the default response. If there is one language in the group and the /lang command is setting, then when it is called, it will return the setting response