### PR TITLE
fix issue: Trying to get property 'key' of non-object

### DIFF
--- a/controllers/SettingController.php
+++ b/controllers/SettingController.php
@@ -8,6 +8,7 @@ use Yii;
 use yii\data\Pagination;
 use yii\filters\AccessControl;
 use yii\web\Controller;
+use yii\web\NotFoundHttpException;
 
 class SettingController extends Controller
 {
@@ -73,6 +74,10 @@ class SettingController extends Controller
 
         $settingValues = SettingValue::find()->where(['setting_id' => $id, 'is_current' => 0])->all();
         $setting = Setting::find()->where(['id' => $id])->one();
+
+        if(empty($setting) || empty($settingValues)){
+            throw new NotFoundHttpException();
+        }
 
         return $this->render('setting-values', [
             'settingValues' => $settingValues,


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

If SettingController sends empty $setting or $settingValues to view it throws an error :
yii\base\ErrorException: Trying to get property 'key' of non-object in /www/opensourcewebsite.org/htdocs/views/setting/setting-values.php:9

so i added and if statement to check $setting and $settingValues and in case they are empty 
trow new NotFoundHttpException(); to show 404 error page.

Issue number #229 .

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Enter any applicable Issues here -->
