### PR TITLE
Fixes for support groups "/support-groups"

### DIFF
--- a/views/support-groups/commands/_edit_text.php
+++ b/views/support-groups/commands/_edit_text.php
@@ -52,9 +52,12 @@ $this->registerJsFile('https://cdnjs.cloudflare.com/ajax/libs/emojionearea/3.4.1
     </div>
 <?php ActiveForm::end(); ?>
 <script>
-  $(document).ready(function() {
+ $(document).ready(function() {
     $("#supportgroupcommandtext-text").emojioneArea({
-        pickerPosition: 'left'
+        pickerPosition: 'left',
+		 attributes: {
+		style: "resize: both;"
+    }
     });
   });
 </script>


### PR DESCRIPTION
Fixes for support groups "/support-groups"

### Requirements

When the user creates a support group, you need to automatically create a "/start" command, in all languages that are connected to the support group, with the message "Welcome!". This command will automatically enable the value "Is default".

Bug. When a command is created in a group with several languages, it is not possible for English to increase the height of the input field (although this works correctly for other languages).

### Description of the Change
![drag1](https://user-images.githubusercontent.com/12140043/69480271-e9f6cb00-0e27-11ea-8dde-b84ed061d3cd.jpg)

And for the input field in other languages there is no way to insert emojis (since this works for English)

### Description of the Change

![emoje](https://user-images.githubusercontent.com/12140043/69480281-0430a900-0e28-11ea-9027-948e73373793.jpg)
