### PR TITLE
ranking fix opensourcewebsite-org#289

### DIFF
--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -319,7 +319,7 @@ class SiteController extends Controller
             $percent = Converter::percentage($rating, $totalRating);
         }
 
-        list($total, $rank) = Rating::getRank($rating);
+        list($total, $rank) = Rating::getRank($model->getId());
 
         return $this->render('account', [
             'model' => $model,

--- a/models/Rating.php
+++ b/models/Rating.php
@@ -22,6 +22,7 @@ class Rating extends \yii\db\ActiveRecord
     const TEAM = 1;
     const DONATE = 2;
     const USE_TELEGRAM_BOT = 3;
+    const UNRANKED = 'unranked';
 
     /**
      * {@inheritdoc}
@@ -77,7 +78,7 @@ class Rating extends \yii\db\ActiveRecord
 
     public static function getRank($userRating)
     {
-        $groupQuery = (new Query)
+        $groupQueryResult = (new Query)
             ->select([
                 '`user`.id',
                 'balance' => 'CASE WHEN SUM(`rating`.`amount`) IS NULL THEN 0 ELSE SUM(`rating`.`amount`) END',
@@ -85,15 +86,17 @@ class Rating extends \yii\db\ActiveRecord
             ->from(User::tableName())
             ->leftJoin(Rating::tableName() . ' ON `user`.`id` = `rating`.`user_id`')
             ->groupBy('`user`.`id`')
-            ->orderBy('balance DESC');
+            ->orderBy(['balance' => 'DESC', 'user.created_at' => 'DESC'])
+            ->all();
 
-        $total = $groupQuery->count();
+        $rank = static::UNRANKED;
+        foreach ($groupQueryResult as $index => $row) {
+            if ($row['id'] == Yii::$app->user->getId()) {
+                $rank = $index + 1;
+            }
+        }
 
-        $rank = (new Query)
-            ->select(['count(*)+1'])
-            ->from(['g' => $groupQuery])
-            ->where(['>', 'balance', $userRating])
-            ->scalar();
+        $total = count($groupQueryResult);
 
         return [$total, $rank];
     }

--- a/models/Rating.php
+++ b/models/Rating.php
@@ -76,7 +76,7 @@ class Rating extends \yii\db\ActiveRecord
         return $totalRating != null ? $totalRating : 0;
     }
 
-    public static function getRank($userRating)
+    public static function getRank($userId)
     {
         $groupQueryResult = (new Query)
             ->select([
@@ -91,7 +91,7 @@ class Rating extends \yii\db\ActiveRecord
 
         $rank = static::UNRANKED;
         foreach ($groupQueryResult as $index => $row) {
-            if ($row['id'] == Yii::$app->user->getId()) {
+            if ($row['id'] == $userId) {
                 $rank = $index + 1;
             }
         }

--- a/modules/bot/controllers/privates/My_ratingController.php
+++ b/modules/bot/controllers/privates/My_ratingController.php
@@ -68,7 +68,7 @@ class My_ratingController extends Controller
             $percent = Converter::percentage($rating, $totalRating);
         }
 
-        list($total, $rank) = Rating::getRank($rating);
+        list($total, $rank) = Rating::getRank($user->getId());
 
         $params = [
             'active_rating' => $activeRating,


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

It takes data [[user_id, balance]] ordered by ['balance' => 'DESC', 'user.created_at' => 'DESC']
and then gets rank by row position

### Alternate Designs

Make it in sql query, but I couldn't come up fast with it.

### Benefits

User rank is going calculate right.

### Possible Drawbacks

If the selection will be large, db and application are on different servers, it can use more resources for trasfer it.

### Verification Process

/account - created 3 users with 0 balance, ordered by created_at

### Applicable Issues

<!-- Enter any applicable Issues here -->
