### PR TITLE
Debt Reduction - доработки

### DIFF
--- a/commands/DebtController.php
+++ b/commands/DebtController.php
@@ -34,6 +34,7 @@ class DebtController extends Controller implements ICronChained
         $this->log = true;
         $this->outputLogState();
 
+        $this->output("Check #1. Data collision between DB tables `debt` and `debt_balance`:");
         $errors = (new BalanceChecker)->run();
 
         if (null === $errors) {
@@ -43,6 +44,16 @@ class DebtController extends Controller implements ICronChained
         } else {
             $count = count($errors);
             $message = "ERROR: found $count data collisions!\n" . VarDumper::dumpAsString($errors);
+            $this->output($message, [Console::FG_RED]);
+        }
+
+        $this->output("\n\nCheck #2. Duplicated users in same generated group of debts:");
+        $invalidDebts = BalanceChecker::checkDebtReductionUniqueGroup();
+        if (empty($invalidDebts)) {
+            $this->output('SUCCESS: no bugs found.', [Console::FG_GREEN]);
+        } else {
+            $count = count($invalidDebts);
+            $message = "ERROR: found $count invalid debts! Their ID:\n" . VarDumper::dumpAsString($invalidDebts);
             $this->output($message, [Console::FG_RED]);
         }
     }
@@ -96,5 +107,7 @@ class DebtController extends Controller implements ICronChained
             $this->output($message, $format);
         };
         $reduction->run();
+
+        $this->output("Finished $class");
     }
 }

--- a/components/debt/BalanceChecker.php
+++ b/components/debt/BalanceChecker.php
@@ -26,6 +26,23 @@ class BalanceChecker extends Component
     /**
      * @throws \yii\db\Exception
      */
+    public static function checkDebtReductionUniqueGroup(): array
+    {
+        $sql = '
+        SELECT d1.id
+        FROM debt as d1
+            JOIN debt as d2 ON d1.from_user_id IN (d2.from_user_id, d2.to_user_id)
+                           AND d1.to_user_id IN (d2.from_user_id, d2.to_user_id)
+                           AND d1.id <> d2.id 
+                           AND d1.`group` = d2.`group`  
+        WHERE d1.`group` IS NOT NULL';
+
+        return Yii::$app->db->createCommand($sql)->queryColumn();
+    }
+
+    /**
+     * @throws \yii\db\Exception
+     */
     private function findSumOfAllDebt(): array
     {
         $sql = '

--- a/components/debt/Reduction.php
+++ b/components/debt/Reduction.php
@@ -258,8 +258,6 @@ class Reduction extends Component
 
     private function log($message, $format = [], $consoleOnly = false)
     {
-        $message .= PHP_EOL;
-
         if ($this->logger && !$consoleOnly) {
             call_user_func($this->logger, $message, $format);
         }
@@ -268,6 +266,7 @@ class Reduction extends Component
             return;
         }
 
+        $message .= PHP_EOL;
         if (!empty($format)) {
             $message = Console::ansiFormat($message, $format);
         }


### PR DESCRIPTION
### Description of the Change
Дополнение к PR #358 : 
- по окончании крон-скрипта `debt` печатается лог `Finished \app\components\debt\Reduction`
- в команду `yii debt/check-balance` добавлена проверка цепочки `Debt` созданных `Reduction` - в цепочке не должно быть 2 `Debt` между одними и теми же юзерами. Т.е. только один `Debt` на пару юзеров.

### Applicable Issues

#294 