### PR TITLE
ui: fix wrong JS confirm alert on page /contact/update

### DIFF
--- a/views/contact/_form.php
+++ b/views/contact/_form.php
@@ -96,7 +96,7 @@ function warnOnDeleteDebtRedistributionSettings() {
     let inputUser = $('#contact-useridorname');
     let newUser = inputUser.val() + '';
     let oldUser = inputUser.attr('data-old-value') + '';
-    if (!oldUser || oldUser === newUser) {
+    if (!oldUser || oldUser === 'undefined' || oldUser === newUser) {
         return true;
     }
 


### PR DESCRIPTION
### Description of the Change

Исправлен UI баг: При редактировании контакта, если поле `User ID / Username (optional)`  пустое срабатывал ненужный JS `confirm`.

### Verification Process

1. https://opensourcewebsite.org/contact/create
2. создать контакт с пустым полем  `User ID / Username (optional)`, в поле `Name (optional)` что то прописать.
3. открыть этот контакт для редактирования. Ничего не меняя сохранить. - Баг - появится confirm окно, которое не должно было появиться.

### Applicable Issues

#294 
