### PR TITLE
cut require email rule

### DIFF
--- a/models/User.php
+++ b/models/User.php
@@ -69,11 +69,6 @@ class User extends ActiveRecord implements IdentityInterface
     public function rules()
     {
         return [
-            [
-                ['email'],
-                'required'
-            ],
-
             ['is_authenticated', 'boolean'],
             [['gender_id', 'sexuality_id', 'currency_id'], 'integer'],
             ['birthday', 'date'],


### PR DESCRIPTION
удалено правило 
> 'email' => 'required'

так как оно вызывало баг при сохранении полей в боте