### PR TITLE
Reduction: optimization, security & debug improvements

### DIFF
--- a/commands/DebtController.php
+++ b/commands/DebtController.php
@@ -20,12 +20,28 @@ class DebtController extends Controller implements CronChainedInterface
 {
     use ControllerLogTrait;
 
+    public $debugReduction;
+
+    public static function formatConsoleArgument($value)
+    {
+        if (is_array($value)) {
+            return base64_encode(json_encode($value));
+        } else {
+            return json_decode(base64_decode($value), true);
+        }
+    }
+
     /**
      * {@inheritdoc}
      */
     public function options($actionID)
     {
-        return $this->optionsAppendLog(parent::options($actionID));
+        $options = parent::options($actionID);
+        if ('index' === $actionID) {
+            $options[] = 'debugReduction';
+        }
+
+        return $this->optionsAppendLog($options);
     }
 
     /**
@@ -112,6 +128,11 @@ class DebtController extends Controller implements CronChainedInterface
         $reduction->logger = function ($message, $format = []) {
             $this->output($message, $format);
         };
+        if ($this->debugReduction) {
+            $reduction->debug['DebtBalanceCondition'] = self::formatConsoleArgument($this->debugReduction);
+            $reduction->debug['logConsole'] = true;
+            $this->log = true;
+        }
         $reduction->run();
 
         $this->output("Finished $class");

--- a/commands/traits/ControllerLogTrait.php
+++ b/commands/traits/ControllerLogTrait.php
@@ -22,7 +22,7 @@ trait ControllerLogTrait
     /**
      * @param string[] $options result from {@see \yii\console\Controller::options()}
      *
-     * @return array
+     * @return string[]
      */
     public function optionsAppendLog($options)
     {

--- a/components/debt/Reduction.php
+++ b/components/debt/Reduction.php
@@ -108,10 +108,12 @@ class Reduction extends Component
             if ($circledChain) {
                 return $circledChain;
             }
+            if (!$this->validateMemoryLimit()) {
+                return null;
+            }
         }
 
-        $breakLevel = $this->breakLevel($level, $chainMembers[0]);
-        if (empty($chainsWithMiddleMember) || $breakLevel || !$this->validateMemoryLimit()) {
+        if (empty($chainsWithMiddleMember) || $this->breakLevel($level, $chainMembers[0])) {
             return null;
         }
 

--- a/config/web.php
+++ b/config/web.php
@@ -107,7 +107,7 @@ $config = [
                 'mail' => [
                     'class' => 'yii\log\EmailTarget',
                     'exportInterval' => 1,
-                    'enabled' => isset($params['securityEmail']) && $params['securityEmail'] && getenv('YII_ENV') !== 'dev' && getenv('YII_DEBUG') !== true,
+                    'enabled' => !empty($params['securityEmail']) && getenv('YII_ENV') !== 'dev' && getenv('YII_DEBUG') !== true,
                     'levels' => ['error'],
                     'logVars' => [],
                     'message' => [

--- a/helpers/Number.php
+++ b/helpers/Number.php
@@ -2,6 +2,8 @@
 
 namespace app\helpers;
 
+use InvalidArgumentException;
+
 /**
  * Class Number
  *
@@ -68,5 +70,33 @@ class Number
     public static function floatAdd(?string $leftFloat, ?string $rightFloat, int $scale): string
     {
         return bcadd($leftFloat, $rightFloat, $scale);
+    }
+
+    public static function sizeToInt(string $size) {
+        $size = trim($size);
+        $last = strtolower($size[strlen($size)-1]);
+        $size = substr($size, 0, -1);
+
+        switch($last) {
+            case 'g':
+                return $size * 1073741824; // 1024*1024*1024
+            case 'm':
+                return $size * 1048576; // 1024*1024
+            case 'k':
+                return $size * 1024;
+            default:
+                throw new InvalidArgumentException("Unexpected shorthand byte received: '$last'. \$size = '$size'");
+        }
+    }
+
+    public static function getMemoryLimit()
+    {
+        $limit = ini_get('memory_limit');
+
+        if (!$limit || -1 === (int)$limit || is_numeric($limit)) {
+            return (float)$limit;
+        }
+
+        return self::sizeToInt($limit);
     }
 }

--- a/helpers/Number.php
+++ b/helpers/Number.php
@@ -72,12 +72,13 @@ class Number
         return bcadd($leftFloat, $rightFloat, $scale);
     }
 
-    public static function sizeToInt(string $size) {
+    public static function sizeToInt(string $size)
+    {
         $size = trim($size);
         $last = strtolower($size[strlen($size)-1]);
         $size = substr($size, 0, -1);
 
-        switch($last) {
+        switch ($last) {
             case 'g':
                 return $size * 1073741824; // 1024*1024*1024
             case 'm':


### PR DESCRIPTION
### Description of the Change

- security improvement - add `Reduction::BREAK_LEVEL`. It allow: 
    - prevent continuous run (in case if system have bugs)
    - prevent too long execution (if DB too large)
- add new debug tool 
    - if `Reduction::BREAK_LEVEL` will be reached - `cron_job_log` will be created. And it will suggest to debug exactly this balance with command like: `yii debt --debug-reduction=eyJjdXJyZW5`
- debug logs were improved
- security improvement - prevent `PHP Fatal error: Out of memory`:
    - log will be generated.
    - current balance will be skipped, and script will analyze next one
- **highly optimized logic!!** - this improvement gives almost nothing, if search loop level is low (0-4). But then, with each new level, it become more important. On 7th level speed increased **in 5 times!** 
    - This is **the most pleasant** change :) 

### Applicable Issues

#294
