### PR TITLE
#438 refactor 'create' and 'update' actions of contacts

### DIFF
--- a/controllers/ContactController.php
+++ b/controllers/ContactController.php
@@ -193,44 +193,13 @@ class ContactController extends Controller
      * Creates a new Contact model.
      * If creation is successful, the browser will be redirected to the 'view' page.
      * @return mixed
-     *
-     * TODO [ref] methods actionCreate and actionUpdate has a lot of duplicated code. Merge logic in common functions
-     *        [ref] validation logic should not be implemented in controller. Move it into Model::rules()
      */
     public function actionCreate()
     {
         $model = new Contact();
-        $model->loadDefaultValues();
 
+        $model->user_id = Yii::$app->user->id;
         if ($model->load(Yii::$app->request->post()) && $model->validate()) {
-            $model->user_id = Yii::$app->user->id;
-            if (!empty($model->userIdOrName)) {
-                if ($model->user_id == $model->userIdOrName) {
-                    Yii::$app->session->setFlash('error', 'User ID / You are trying to enter your ID.');
-
-                    return $this->render('create', [
-                        'model' => $model,
-                    ]);
-                }
-                $user = User::find()
-                    ->andWhere([
-                        'OR',
-                        ['id' => $model->userIdOrName],
-                        ['username' => $model->userIdOrName]
-                    ])
-                    ->one();
-                if (!empty($user->contact)) {
-                    $contact = $user->contact;
-                    $contact->link_user_id = null;
-                    $contact->save(false);
-                }
-                $model->link_user_id = $user->id;
-
-                $model->save(false);
-
-                return $this->redirect(['view', 'id' => $model->id]);
-            }
-
             $model->save(false);
             return $this->redirect(['view', 'id' => $model->id]);
         }
@@ -252,32 +221,8 @@ class ContactController extends Controller
         $model = $this->findModel($id);
         $model->userIdOrName = $model->getUserIdOrName();
 
+        $model->user_id = Yii::$app->user->id;
         if ($model->load(Yii::$app->request->post()) && $model->validate()) {
-            $model->user_id = Yii::$app->user->id;
-            if (!empty($model->userIdOrName)) {
-                if ($model->user_id == $model->userIdOrName) {
-                    Yii::$app->session->setFlash('error', 'User ID / You are trying to enter your ID.');
-
-                    return $this->render('update', [
-                        'model' => $model,
-                    ]);
-                }
-                $user = User::find()
-                    ->andWhere([
-                        'OR',
-                        ['id' => $model->userIdOrName],
-                        ['username' => $model->userIdOrName]
-                    ])
-                    ->one();
-                if (!empty($user->contact) && ((int) $user->contact->id !== (int) $id)) {
-                    $contact = $user->contact;
-                    $contact->link_user_id = null;
-                    $contact->save(false);
-                }
-                $model->link_user_id = $user->id;
-            } else {
-                $model->link_user_id = null;
-            }
             $model->save(false);
             return $this->redirect(['view', 'id' => $model->id]);
         }

--- a/tests/unit/models/ContactTest.php
+++ b/tests/unit/models/ContactTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace models;
+
+use Yii;
+use app\models\User;
+use app\models\Contact;
+use app\tests\fixtures\UserFixture;
+use app\tests\fixtures\ContactFixture;
+
+class ContactTest extends \Codeception\Test\Unit
+{
+    /**
+     * @var \UnitTester
+     */
+    protected $tester;
+
+    // fixture data located in tests/_data/*.php
+    public function _fixtures()
+    {
+        return [
+            'user'    => [
+                'class'    => UserFixture::class,
+                'dataFile' => codecept_data_dir() . 'user.php',
+            ],
+            'contact' => [
+                'class'    => ContactFixture::className(),
+                'dataFile' => codecept_data_dir() . 'contact.php',
+            ],
+        ];
+    }
+    
+    protected function _before()
+    {
+        parent::_before();
+
+        $user = User::findOne(['email' => 'admin@example.com']); // id=100
+        Yii::$app->user->login($user, 3600);
+    }
+
+    protected function _after()
+    {
+        Yii::$app->user->logout();
+
+        parent::_after();
+    }
+
+    public function testCreateWithOwnerAndLinkedUsersSame()
+    {
+        $contact = new Contact();
+
+        $contact->user_id = "103";
+        $contact->userIdOrName = "103";
+
+        expect("Contact can't be saved because owner and linked users can't be same", $contact->save())->false();
+        expect("Attribute 'userIdOrName' is not valid because it's equal to user owner", $contact->hasErrors("userIdOrName"))->true();
+    }
+
+    public function testUpdateWithOwnerAndLinkedUsersSame()
+    {
+        $contact = Contact::find()->where(['id' => 1])->one();
+
+        $contact->userIdOrName = (string) $contact->user_id;
+
+        expect("Contact can't be updated because owner and linked users can't be same", $contact->save())->false();
+        expect("Attribute 'userIdOrName' is not valid because it's equal to user owner", $contact->hasErrors("userIdOrName"))->true();
+    }
+
+    public function testContactBecomesVirtual()
+    {
+        $prevContact = new Contact();
+        $prevContact->user_id = Yii::$app->user->id;
+        $prevContact->userIdOrName = "101";
+        expect("prevContact save() is success", $prevContact->save())->true();
+        expect("prevContact is not virtual", !$prevContact->isVirtual())->true();
+
+        $newContact = new Contact();
+        $newContact->userIdOrName = $prevContact->userIdOrName;
+        $newContact->user_id = $prevContact->user_id;
+        expect("newContact save() is success", $newContact->save())->true();
+
+        $prevContact->refresh();
+        expect("prevContact becomes virtual, because newContact has same owner and linked users", $prevContact->isVirtual())->true();
+    }
+}


### PR DESCRIPTION
refactor 'actionCreate' and 'actionUpdate' in ContactController:

- move duplicated code from actions to Contact::beforeSave;
- add 'validateLinkUserAndOwnerNotSame' validation method to check if user entered in field 'User ID / Username (optional)' of Contact form his own id or username;
- add tests for this changes.