### PR TITLE
#599 add reload button in authenticate page

### DIFF
--- a/views/site/login.php
+++ b/views/site/login.php
@@ -32,7 +32,17 @@ $this->params['breadcrumbs'][] = $this->title;
                     <?= $form->field($model, 'password')->passwordInput() ?>
                 </div>
                 <div class="form-group">
-                    <?= $form->field($model, 'captcha')->widget(Captcha::className()) ?>
+                    <?= $form->field($model, 'captcha')->widget(Captcha::className(), [
+                        'template' => '{image}'.Html::button('<span class="fas fa-refresh"></span>', ['id' => 'refresh-captcha', 'class' => 'btn btn-primary']).'{input}'
+                    ]) ?>
+                    <?= $this->registerJs("
+                            $('#refresh-captcha').on('click', function(e){
+                                e.preventDefault();
+                                $('#loginform-captcha-image').yiiCaptcha('refresh');
+                            })
+                        "); 
+                    ?>
+
                 </div>
 
                 <div>

--- a/views/site/request-reset-password.php
+++ b/views/site/request-reset-password.php
@@ -29,7 +29,16 @@ $this->params['breadcrumbs'][] = $this->title;
                   <?= $form->field($model, 'email')->textInput(['autofocus' => true]) ?>
               </div>
               <div class="form-group">
-                  <?= $form->field($model, 'captcha')->widget(Captcha::className()) ?>
+                <?= $form->field($model, 'captcha')->widget(Captcha::className(), [
+                    'template' => '{image}'.Html::button('<span class="fas fa-refresh"></span>', ['id' => 'refresh-captcha', 'class' => 'btn btn-primary']).'{input}'
+                ]) ?>
+                <?= $this->registerJs("
+                        $('#refresh-captcha').on('click', function(e){
+                            e.preventDefault();
+                            $('#requestresetpasswordform-captcha-image').yiiCaptcha('refresh');
+                        })
+                    "); 
+                ?>
               </div>
 
               <div>

--- a/views/site/signup.php
+++ b/views/site/signup.php
@@ -33,7 +33,16 @@ $this->params['breadcrumbs'][] = $this->title;
                     <?= $form->field($model, 'password_repeat')->passwordInput() ?>
                 </div>
                 <div class="form-group">
-                    <?= $form->field($model, 'captcha')->widget(Captcha::className()) ?>
+                    <?= $form->field($model, 'captcha')->widget(Captcha::className(), [
+                        'template' => '{image}'.Html::button('<span class="fas fa-refresh"></span>', ['id' => 'refresh-captcha', 'class' => 'btn btn-primary']).'{input}'
+                    ]) ?>
+                    <?= $this->registerJs("
+                            $('#refresh-captcha').on('click', function(e){
+                                e.preventDefault();
+                                $('#signupform-captcha-image').yiiCaptcha('refresh');
+                            })
+                        "); 
+                    ?>
                 </div>
 
                 <div>


### PR DESCRIPTION
#599 add reload button in authenticate page

### Description of the Change

I added a function and a button to refresh the capcha image on  login, signup, and forgot password page.

### Alternate Designs

just added button and function

### Benefits

you can refresh image with button aside of image

### Possible Drawbacks


### Verification Process

push to my fork, and pull request for validation


### Applicable Issues


