### PR TITLE
Bot. Group. Remove locations in groups. (#653)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,3 @@ php-cs-fixer.phar
 
 # cache for php-cs-fixer
 .php-cs-fixer.cache
-
-ngrok.exe

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ php-cs-fixer.phar
 
 # cache for php-cs-fixer
 .php-cs-fixer.cache
+
+ngrok.exe

--- a/config/db.php
+++ b/config/db.php
@@ -4,7 +4,7 @@ return [
     'class' => 'yii\db\Connection',
     'dsn' => 'mysql:host=' . (getenv('DB_HOST') ?: 'localhost') . ';port=' . (getenv('DB_PORT') ?: '3306') . ';dbname=' . (getenv('DB_NAME') ?: 'opensourcewebsite'),
     'username' => getenv('DB_USERNAME') ?: 'root',
-    'password' => getenv('DB_PASSWORD'),
+    'password' => getenv('DB_PASSWORD') ?: 'root',
     'charset' => getenv('DB_CHARSET') ?: 'utf8mb4',
     'attributes' => [
         PDO::ATTR_CASE => PDO::CASE_LOWER,

--- a/config/db.php
+++ b/config/db.php
@@ -4,7 +4,7 @@ return [
     'class' => 'yii\db\Connection',
     'dsn' => 'mysql:host=' . (getenv('DB_HOST') ?: 'localhost') . ';port=' . (getenv('DB_PORT') ?: '3306') . ';dbname=' . (getenv('DB_NAME') ?: 'opensourcewebsite'),
     'username' => getenv('DB_USERNAME') ?: 'root',
-    'password' => getenv('DB_PASSWORD') ?: 'root',
+    'password' => getenv('DB_PASSWORD'),
     'charset' => getenv('DB_CHARSET') ?: 'utf8mb4',
     'attributes' => [
         PDO::ATTR_CASE => PDO::CASE_LOWER,

--- a/messages/ru/bot.php
+++ b/messages/ru/bot.php
@@ -576,6 +576,7 @@ return [
     'Some @username is present' => 'Присутствует какой то @username',
     'Emoji are present' => 'Присутствуют эмодзи',
     'Unallowed text elements are present' => 'Присутствуют не разрешенные текстовые элементы',
+    'Location are present' => 'Присутствует геолокация',
     'Styled text is present' => 'Присутствует стилизованный текст',
     'You have exceeded the allowed posting frequency' => 'Вы превысили разрешенную частоту публикации сообщений',
     'Try again later or tomorrow' => 'Повторите попытку позже или завтра',

--- a/modules/bot/components/api/BotApi.php
+++ b/modules/bot/components/api/BotApi.php
@@ -55,10 +55,10 @@ class BotApi extends \TelegramBot\Api\BotApi
     }
 
     /**
-    * @param $callbackQueryId
-    * @param string|null $text
-    * @param bool $showAlert
-    * @return bool
+     * @param $callbackQueryId
+     * @param string|null $text
+     * @param bool $showAlert
+     * @return bool
      */
     public function answerCallbackQuery($callbackQueryId, $text = null, $showAlert = false, $url = null, $cacheTime = 0)
     {

--- a/modules/bot/controllers/privates/GroupMessageFilterController.php
+++ b/modules/bot/controllers/privates/GroupMessageFilterController.php
@@ -26,7 +26,8 @@ class GroupMessageFilterController extends Controller
         3 => 'filter_remove_emoji',
         4 => 'filter_remove_empty_line',
         5 => 'filter_remove_channels',
-        6 => 'filter_remove_styled_texts',
+        6 => 'filter_remove_locations',
+        7 => 'filter_remove_styled_texts',
     ];
 
     public function actions()
@@ -154,6 +155,15 @@ class GroupMessageFilterController extends Controller
                             'callback_data' => self::createRoute('set-status', [
                                 'id' => $chat->id,
                                 'i' => 6,
+                            ]),
+                            'text' => ($chat->filter_remove_locations == ChatSetting::STATUS_ON ? Emoji::STATUS_ON : Emoji::STATUS_OFF) . ' ' . Yii::t('bot', 'Remove: locations'),
+                        ],
+                    ],
+                    [
+                        [
+                            'callback_data' => self::createRoute('set-status', [
+                                'id' => $chat->id,
+                                'i' => 7,
                             ]),
                             'text' => ($chat->filter_remove_styled_texts == ChatSetting::STATUS_ON ? Emoji::STATUS_ON : Emoji::STATUS_OFF) . ' ' . Yii::t('bot', 'Remove: styled texts'),
                         ],

--- a/modules/bot/controllers/privates/GroupMessageFilterController.php
+++ b/modules/bot/controllers/privates/GroupMessageFilterController.php
@@ -26,8 +26,8 @@ class GroupMessageFilterController extends Controller
         3 => 'filter_remove_emoji',
         4 => 'filter_remove_empty_line',
         5 => 'filter_remove_channels',
-        6 => 'filter_remove_locations',
-        7 => 'filter_remove_styled_texts',
+        6 => 'filter_remove_styled_texts',
+        7 => 'filter_remove_locations',
     ];
 
     public function actions()
@@ -156,7 +156,7 @@ class GroupMessageFilterController extends Controller
                                 'id' => $chat->id,
                                 'i' => 6,
                             ]),
-                            'text' => ($chat->filter_remove_locations == ChatSetting::STATUS_ON ? Emoji::STATUS_ON : Emoji::STATUS_OFF) . ' ' . Yii::t('bot', 'Remove: locations'),
+                            'text' => ($chat->filter_remove_styled_texts == ChatSetting::STATUS_ON ? Emoji::STATUS_ON : Emoji::STATUS_OFF) . ' ' . Yii::t('bot', 'Remove: styled texts'),
                         ],
                     ],
                     [
@@ -165,7 +165,7 @@ class GroupMessageFilterController extends Controller
                                 'id' => $chat->id,
                                 'i' => 7,
                             ]),
-                            'text' => ($chat->filter_remove_styled_texts == ChatSetting::STATUS_ON ? Emoji::STATUS_ON : Emoji::STATUS_OFF) . ' ' . Yii::t('bot', 'Remove: styled texts'),
+                            'text' => ($chat->filter_remove_locations == ChatSetting::STATUS_ON ? Emoji::STATUS_ON : Emoji::STATUS_OFF) . ' ' . Yii::t('bot', 'Remove: locations'),
                         ],
                     ],
                     [

--- a/modules/bot/models/ChatSetting.php
+++ b/modules/bot/models/ChatSetting.php
@@ -109,6 +109,9 @@ class ChatSetting extends ActiveRecord
         'filter_remove_channels' => [
             'default' => self::STATUS_OFF,
         ],
+        'filter_remove_locations' => [
+            'default' => self::STATUS_OFF,
+        ],
         'filter_remove_styled_texts' => [
             'default' => self::STATUS_OFF,
         ],

--- a/modules/bot/views/groups/privates/warning-filter-remove-locations.php
+++ b/modules/bot/views/groups/privates/warning-filter-remove-locations.php
@@ -1,0 +1,5 @@
+<b><?= $chat->title ?></b><?= $chat->username ? ' (@' . $chat->username . ')' : '' ?><br/>
+<br/>
+<?= Yii::t('bot', 'Your last message in the group was deleted because') ?>:<br/>
+<br/>
+<?= Yii::t('bot', 'Location are present') ?>.


### PR DESCRIPTION
* Added "Remove: locations" button to the list of message filters

* When the filter is activated, geolocations sent to the group are deleted
